### PR TITLE
feat(channels): add ghcr pull secret ahead of package going private

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,3 +15,4 @@ _Avoid_: notification entity, trigger sensor (too generic — this is specifical
 ## Related vocabulary (owned by sibling repos)
 
 - **Trusted Zone / Restricted Zone / Pinhole** — network segmentation vocabulary for VLANs, defined in the `mikrotik` repo's `CONTEXT.md`. Referenced but not redefined here; see [ADR-0002](./docs/adr/0002-macvlan-dual-homing-for-cross-vlan-device-discovery.md) for how this cluster's workloads interact with those zones.
+- **AMF / Bundled ffmpeg / Terminal pin** — vocabulary for what actually consumes a GPU Share inside the Channels DVR container, defined in the `packages` repo's `CONTEXT.md`. Relevant here because [ADR-0003](./docs/adr/0003-reject-amd-gpu-operator-for-integrated-graphics.md)'s `/dev/kfd` finding is a constraint on that image, and because Channels' hardware encoding is AMF-only — VA-API is structurally unavailable to it, so a working Jellyfin VA-API path implies nothing about Channels.

--- a/kubernetes/apps/yarr/channels/app/helmrelease.yaml
+++ b/kubernetes/apps/yarr/channels/app/helmrelease.yaml
@@ -58,6 +58,8 @@ spec:
                 memory: 16Gi
                 devic.es/dri-render: 1
     defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr
       securityContext:
         runAsNonRoot: true
         runAsUser: 568


### PR DESCRIPTION
Prerequisite for making `ghcr.io/rwade628/channels-dvr` a private package (it redistributes AMD's proprietary AMF libraries — see rwade628/packages#1).

The container sets `imagePullPolicy: Always`, so flipping the package to private **without** this change would leave the DVR in `ImagePullBackOff` on its next restart or reschedule. The `ghcr` secret already exists in `yarr` via `components/sops`, and `yarr/webhook` already consumes it the same way.

Safe to merge on its own — adding a pull secret for an image that's still public is a no-op.

Also adds a cross-reference from `CONTEXT.md` to the `packages` repo's glossary, covering why Channels DVR is AMF-only (a working Jellyfin VA-API path implies nothing about Channels) and where the `/dev/kfd` requirement from ADR-0003 is depended on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)