### PR TITLE
feat(channels): cut over to rebuilt AMD image

### DIFF
--- a/kubernetes/apps/yarr/channels/app/helmrelease.yaml
+++ b/kubernetes/apps/yarr/channels/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/rwade628/channels-dvr
-              tag: amd@sha256:e2a9564b91d17f6a8c901074d39d286248eb23303bfc6a02658291f42beafa39
+              tag: amd-next@sha256:b89002d545448e6e3c148c878781ed86f8dabdc6b6eba7d63c5ecb77c0112a3a
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
Points channels-dvr at the rebuilt image from rwade628/packages#1.

```
- amd@sha256:e2a9564b91d17f6a8c901074d39d286248eb23303bfc6a02658291f42beafa39
+ amd-next@sha256:b89002d545448e6e3c148c878781ed86f8dabdc6b6eba7d63c5ecb77c0112a3a
```

The AMF library set in the new image is **byte-identical** to the one this replaces — same five files, same sizes, same timestamps. What changed is everything around it: the inert VA-API stack is gone, the libraries are exposed via `ld.so.conf.d` instead of `LD_LIBRARY_PATH`, and Mesa gets a writable capped shader cache (the pod runs read-only with `HOME=/`, so RADV's cache was silently disabled).

Staying on the `amd-next` tag until verified on the 780M, then promoted to `amd`.

## Verification after merge

Hardware transcoding fails silently, so a running pod proves nothing:

1. `POST /hls/hwaccel` → `[HWE]` selects `h264_amf` / `AMF initialisation succeeded via Vulkan`
2. No `Failed to create //.cache for shader cache` warning
3. A real recording transcodes

DVR confirmed idle (`busy: false`, no activity) at time of writing, so the `Recreate` restart is safe.

## Rollback

Revert this commit. Flux reconciles back to the previous digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)